### PR TITLE
Add labels for task and note inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,477 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Codex-Ready: Study Starter App</title>
+<style>
+  :root{
+    --bg1:#f7f8fa;
+    --bg2:#eceff3;
+    --ink:#111;
+    --ink-secondary:#444;
+    --accent:#4f46e5;
+    --ok:#16a34a;
+    --warn:#dc2626;
+    --card:#fff;
+    --shadow: 0 10px 30px rgba(0,0,0,.07);
+    --radius: 18px;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{
+    margin:0;
+    font-family: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";
+    color:var(--ink);
+    background: linear-gradient(135deg, var(--bg1), var(--bg2));
+  }
+  header{
+    position:sticky;top:0;z-index:5;
+    backdrop-filter:saturate(180%) blur(8px);
+    background:linear-gradient(180deg, rgba(255,255,255,.85), rgba(255,255,255,.6));
+    border-bottom:1px solid rgba(0,0,0,.06);
+  }
+  .wrap{max-width:980px;margin:0 auto;padding:24px}
+  .title{
+    display:flex;align-items:center;gap:12px;
+  }
+  .logo{
+    width:36px;height:36px;border-radius:12px;
+    background: radial-gradient(circle at 30% 30%, #8b5cf6, #4f46e5 60%, #0ea5e9);
+    box-shadow: var(--shadow);
+  }
+  h1{font-size:22px;margin:0}
+  .tabs{
+    display:flex;gap:10px;margin-top:14px;flex-wrap:wrap
+  }
+  .tab-btn{
+    border:none;padding:10px 14px;border-radius:999px;
+    background:#fff;box-shadow: var(--shadow);cursor:pointer;
+    color:var(--ink-secondary);font-weight:600;letter-spacing:.2px
+  }
+  .tab-btn.active{background:var(--ink);color:#fff}
+  main{padding:18px}
+  .grid{
+    display:grid;gap:18px;
+    grid-template-columns: 1fr;
+  }
+  @media(min-width:900px){
+    .grid{grid-template-columns: 1.2fr 1fr;}
+  }
+  .card{
+    background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);
+    padding:18px;
+  }
+  .section-title{margin:0 0 10px 0;font-size:18px}
+  .muted{color:var(--ink-secondary);font-size:12px}
+    input[type="text"], input[type="number"], textarea{
+      width:100%;padding:12px 14px;border-radius:12px;border:1px solid rgba(0,0,0,.08);
+      background:#fff;font-size:14px;outline:none
+    }
+    textarea{min-height:160px;resize:vertical}
+    .sr-only{
+      position:absolute;
+      width:1px;
+      height:1px;
+      padding:0;
+      margin:-1px;
+      overflow:hidden;
+      clip:rect(0,0,0,0);
+      white-space:nowrap;
+      border:0;
+    }
+    .row{display:flex;gap:10px;align-items:center}
+    .row.wrap{flex-wrap:wrap}
+    .btn{
+      border:none;border-radius:12px;padding:10px 14px;font-weight:700;cursor:pointer;
+      background:var(--accent);color:#fff;box-shadow: var(--shadow)
+  }
+  .btn.ghost{background:#fff;color:var(--ink);border:1px solid rgba(0,0,0,.08)}
+  .btn.ok{background:var(--ok)}
+  .btn.warn{background:var(--warn)}
+  ul.tasks{list-style:none;margin:10px 0 0 0;padding:0}
+  .task{
+    display:flex;align-items:center;gap:10px;
+    padding:10px;border:1px solid rgba(0,0,0,.06);border-radius:12px;margin-bottom:10px;background:#fff;
+  }
+  .task.done{opacity:.6;text-decoration:line-through}
+  .spacer{flex:1}
+  .pill{font-size:12px;padding:6px 10px;border-radius:999px;background:#f1f5f9}
+  .counts{display:flex;gap:8px;flex-wrap:wrap}
+  .progress-wrap{height:10px;background:#eef2ff;border-radius:999px;overflow:hidden}
+  .progress{height:100%;width:0%;background:var(--accent);transition:width .2s ease}
+  .timer-big{font-size:48px;font-weight:800;letter-spacing:1px;margin:10px 0}
+  .preview{
+    border:1px dashed rgba(0,0,0,.1);border-radius:12px;padding:12px;background:#fafafa;max-height:340px;overflow:auto
+  }
+  .tip{font-size:12px;color:#666;margin-top:8px}
+  footer{padding:20px;text-align:center;color:#666}
+  code.kbd{
+    font-family: ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+    background:#111;color:#fff;border-radius:8px;padding:4px 8px;font-size:12px
+  }
+</style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <div class="title">
+        <div class="logo" aria-hidden="true"></div>
+        <div>
+          <h1>Study Starter App</h1>
+          <div class="muted">タスク / ポモドーロ / ノート（ローカル保存）。Codexで改造しやすい構成。</div>
+        </div>
+      </div>
+      <div class="tabs" role="tablist" aria-label="sections">
+        <button class="tab-btn active" data-tab="tasks" role="tab" aria-selected="true">タスク</button>
+        <button class="tab-btn" data-tab="timer" role="tab" aria-selected="false">タイマー</button>
+        <button class="tab-btn" data-tab="notes" role="tab" aria-selected="false">ノート</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <section id="tasks" class="grid tab">
+      <div class="card">
+        <h2 class="section-title">今日のタスク</h2>
+          <div class="row wrap">
+            <label for="taskInput" class="sr-only">新しいタスク</label>
+            <input id="taskInput" type="text" placeholder="例：英単語 200語 / 世界史 パノラマ1章" />
+            <button id="addTask" class="btn">追加</button>
+            <button id="clearDone" class="btn ghost">完了を一括削除</button>
+          </div>
+        <div style="margin:10px 0" class="counts">
+          <span class="pill" id="cntAll">All 0</span>
+          <span class="pill" id="cntOpen">Open 0</span>
+          <span class="pill" id="cntDone">Done 0</span>
+        </div>
+        <ul class="tasks" id="taskList" aria-live="polite"></ul>
+      </div>
+      <div class="card">
+        <h2 class="section-title">ミニ蔵書</h2>
+        <div class="tip">Codex改造ヒント：<br>
+          <code class="kbd">renderTasks()</code> にタグや締切、ドラッグ並び替えを追加してみよう。<br>
+          <code class="kbd">save()</code> / <code class="kbd">load()</code> でデータ構造を広げてもOK。
+        </div>
+      </div>
+    </section>
+
+    <section id="timer" class="grid tab" style="display:none">
+      <div class="card">
+        <h2 class="section-title">ポモドーロ</h2>
+        <div class="row wrap">
+          <label class="pill">作業 <input id="workMins" type="number" min="1" value="25" style="width:80px;margin-left:8px"></label>
+          <label class="pill">休憩 <input id="breakMins" type="number" min="1" value="5" style="width:80px;margin-left:8px"></label>
+          <button id="startTimer" class="btn ok">スタート</button>
+          <button id="pauseTimer" class="btn ghost">一時停止</button>
+          <button id="resetTimer" class="btn warn">リセット</button>
+        </div>
+        <div class="timer-big" id="timeLeft">25:00</div>
+        <div class="progress-wrap"><div id="progress" class="progress"></div></div>
+        <div class="tip">完了時に音を鳴らす・自動で休憩に遷移する等は <code class="kbd">tick()</code> に追記。</div>
+      </div>
+      <div class="card">
+        <h2 class="section-title">セッション履歴</h2>
+        <ul class="tasks" id="sessionList"></ul>
+      </div>
+    </section>
+
+    <section id="notes" class="grid tab" style="display:none">
+      <div class="card">
+          <h2 class="section-title">クイックノート</h2>
+          <label for="note" class="sr-only">ノート</label>
+          <textarea id="note" placeholder="ここにメモ。Ctrl/Cmd + S で保存"></textarea>
+          <div class="row" style="margin-top:10px">
+            <button id="saveNote" class="btn">保存</button>
+            <button id="clearNote" class="btn ghost">削除</button>
+            <span class="spacer"></span>
+            <span class="muted">ローカル保存。ファイルには送信されません。</span>
+        </div>
+      </div>
+      <div class="card">
+        <h2 class="section-title">簡易プレビュー（マークダウン風）</h2>
+        <div id="preview" class="preview">**太字**、*斜体*、`コード`、行頭に "- " でリスト</div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <span class="muted">© 2025 Study Starter · Vanilla JS only · MIT-like</span>
+  </footer>
+
+<script>
+(() => {
+  // --- tiny utils ---
+  const $ = sel => document.querySelector(sel);
+  const $$ = sel => Array.from(document.querySelectorAll(sel));
+  const storageKey = 'study-starter-v1';
+  const now = () => new Date().toISOString();
+
+  // --- state ---
+  const state = {
+    tasks: [],
+    sessions: [],
+    settings: {work:25, break:5},
+    note: ''
+  };
+
+  function load(){
+    try{
+      const raw = localStorage.getItem(storageKey);
+      if(!raw) return;
+      const obj = JSON.parse(raw);
+      Object.assign(state, obj);
+    }catch(e){ console.warn('load failed', e); }
+  }
+
+  function save(){
+    try{
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    }catch(e){ console.warn('save failed', e); }
+  }
+
+  // --- tabs ---
+  $$(".tab-btn").forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      $$(".tab-btn").forEach(b=>b.classList.remove('active'));
+      btn.classList.add('active');
+      const name = btn.dataset.tab;
+      $$(".tab").forEach(sec=>sec.style.display = (sec.id===name)?'grid':'none');
+    });
+  });
+
+  // --- tasks ---
+  const taskInput = $("#taskInput");
+  const taskList = $("#taskList");
+  const addTaskBtn = $("#addTask");
+  const clearDoneBtn = $("#clearDone");
+
+  function addTask(text){
+    if(!text.trim()) return;
+    state.tasks.push({id:crypto.randomUUID(), text:text.trim(), done:false, createdAt:now()});
+    save(); renderTasks();
+  }
+
+  function toggleTask(id){
+    const t = state.tasks.find(t=>t.id===id);
+    if(!t) return;
+    t.done = !t.done; save(); renderTasks();
+  }
+
+  function deleteTask(id){
+    state.tasks = state.tasks.filter(t=>t.id!==id); save(); renderTasks();
+  }
+
+  function renderTasks(){
+    taskList.innerHTML = '';
+    state.tasks.forEach(t=>{
+      const li = document.createElement('li');
+      li.className = 'task' + (t.done?' done':'');
+      li.innerHTML = `
+        <input type="checkbox" ${t.done?'checked':''} aria-label="done">
+        <div style="flex:1">${escapeHtml(t.text)}</div>
+        <button class="btn ghost" aria-label="delete">削除</button>
+      `;
+      li.querySelector('input').addEventListener('change', ()=>toggleTask(t.id));
+      li.querySelector('button').addEventListener('click', ()=>deleteTask(t.id));
+      taskList.appendChild(li);
+    });
+    const all = state.tasks.length;
+    const done = state.tasks.filter(t=>t.done).length;
+    const open = all - done;
+    $("#cntAll").textContent = `All ${all}`;
+    $("#cntOpen").textContent = `Open ${open}`;
+    $("#cntDone").textContent = `Done ${done}`;
+  }
+
+  addTaskBtn.addEventListener('click', ()=>{ addTask(taskInput.value); taskInput.value=''; taskInput.focus(); });
+  taskInput.addEventListener('keydown', (e)=>{ if(e.key==='Enter'){ addTask(taskInput.value); taskInput.value=''; }});
+  clearDoneBtn.addEventListener('click', ()=>{
+    state.tasks = state.tasks.filter(t=>!t.done); save(); renderTasks();
+  });
+
+  // --- timer ---
+  const workMins = $("#workMins");
+  const breakMins = $("#breakMins");
+  const startBtn = $("#startTimer");
+  const pauseBtn = $("#pauseTimer");
+  const resetBtn = $("#resetTimer");
+  const timeLeftEl = $("#timeLeft");
+  const progressEl = $("#progress");
+  const sessionList = $("#sessionList");
+
+  let timer = { mode: 'work', totalSec: 1500, leftSec:1500, running:false, until:null };
+
+  function applySettings(){
+    state.settings.work = Math.max(1, parseInt(workMins.value||'25',10));
+    state.settings.break = Math.max(1, parseInt(breakMins.value||'5',10));
+    if(timer.mode==='work'){
+      timer.totalSec = state.settings.work * 60;
+    } else {
+      timer.totalSec = state.settings.break * 60;
+    }
+    timer.leftSec = timer.totalSec;
+    timer.until = null;
+    renderTimer();
+    save();
+  }
+
+  workMins.addEventListener('change', applySettings);
+  breakMins.addEventListener('change', applySettings);
+
+  function format(sec){
+    const m = Math.floor(sec/60).toString().padStart(2,'0');
+    const s = (sec%60).toString().padStart(2,'0');
+    return `${m}:${s}`;
+  }
+
+  function renderTimer(){
+    timeLeftEl.textContent = format(timer.leftSec);
+    const pct = 100 * (1 - (timer.leftSec / timer.totalSec));
+    progressEl.style.width = `${pct}%`;
+  }
+
+  function addSession(mode, seconds){
+    state.sessions.unshift({id:crypto.randomUUID(), mode, seconds, at: now()});
+    if(state.sessions.length>50) state.sessions.pop();
+    save(); renderSessions();
+  }
+
+  function renderSessions(){
+    sessionList.innerHTML = '';
+    state.sessions.forEach(s=>{
+      const li = document.createElement('li');
+      const min = Math.round(s.seconds/60);
+      li.className='task';
+      li.innerHTML = `
+        <div class="pill">${s.mode==='work'?'作業':'休憩'}</div>
+        <div style="margin-left:8px">${new Date(s.at).toLocaleString()}</div>
+        <div class="spacer"></div>
+        <div>${min} min</div>
+      `;
+      sessionList.appendChild(li);
+    });
+  }
+
+  let rafId = null;
+  function tick(){
+    if(!timer.running) return;
+    const nowMs = Date.now();
+    timer.leftSec = Math.max(0, Math.ceil((timer.until - nowMs)/1000));
+    renderTimer();
+    if(timer.leftSec<=0){
+      timer.running = false;
+      addSession(timer.mode, timer.totalSec);
+      // 自動でモード切替
+      timer.mode = (timer.mode==='work') ? 'break' : 'work';
+      applySettings();
+      // 自動スタートしたい場合は以下を解除
+      // startTimer();
+      // 簡易音
+      try{ new AudioContext().resume().then(()=>beep()); }catch{}
+      return;
+    }
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function beep(){
+    const ctx = new (window.AudioContext||window.webkitAudioContext)();
+    const o = ctx.createOscillator(); const g = ctx.createGain();
+    o.connect(g); g.connect(ctx.destination);
+    o.type='sine'; o.frequency.value=880;
+    g.gain.setValueAtTime(0.0001, ctx.currentTime);
+    g.gain.exponentialRampToValueAtTime(0.3, ctx.currentTime+0.02);
+    g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime+0.25);
+    o.start(); o.stop(ctx.currentTime+0.26);
+  }
+
+  function startTimer(){
+    if(timer.running) return;
+    timer.running = true;
+    timer.until = Date.now() + timer.leftSec*1000;
+    tick();
+  }
+  function pauseTimer(){
+    timer.running = false;
+    if(rafId) cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+  function resetTimer(){
+    pauseTimer();
+    timer.leftSec = timer.totalSec;
+    renderTimer();
+  }
+
+  startBtn.addEventListener('click', startTimer);
+  pauseBtn.addEventListener('click', pauseTimer);
+  resetBtn.addEventListener('click', resetTimer);
+
+  // --- notes ---
+  const noteEl = $("#note");
+  const saveNoteBtn = $("#saveNote");
+  const clearNoteBtn = $("#clearNote");
+  const previewEl = $("#preview");
+
+  function mdLite(src){
+    // very tiny markdown-like transform
+    let s = escapeHtml(src);
+    s = s.replace(/^###### (.*)$/gm, '<h6>$1</h6>')
+         .replace(/^##### (.*)$/gm, '<h5>$1</h5>')
+         .replace(/^#### (.*)$/gm, '<h4>$1</h4>')
+         .replace(/^### (.*)$/gm, '<h3>$1</h3>')
+         .replace(/^## (.*)$/gm, '<h2>$1</h2>')
+         .replace(/^# (.*)$/gm, '<h1>$1</h1>');
+    s = s.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+         .replace(/\*(.+?)\*/g, '<em>$1</em>')
+         .replace(/`([^`]+?)`/g, '<code>$1</code>');
+    // lists
+    s = s.replace(/^(?:- |\* )(.*)$/gm, '<li>$1</li>');
+    s = s.replace(/(<li>.*<\/li>)/gs, '<ul>$1</ul>');
+    // paragraphs
+    s = s.replace(/(?:\r?\n){2,}/g, '</p><p>');
+    return '<p>'+s+'</p>';
+  }
+
+  function renderNote(){
+    previewEl.innerHTML = mdLite(state.note || '');
+  }
+
+  saveNoteBtn.addEventListener('click', ()=>{ state.note = noteEl.value; save(); renderNote(); });
+  clearNoteBtn.addEventListener('click', ()=>{ state.note=''; noteEl.value=''; save(); renderNote(); });
+  noteEl.addEventListener('input', ()=>{ state.note = noteEl.value; save(); renderNote(); });
+  document.addEventListener('keydown', (e)=>{
+    if((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='s'){
+      e.preventDefault(); state.note = noteEl.value; save(); renderNote();
+    }
+  });
+
+  // --- safety ---
+  function escapeHtml(s){
+    return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  // --- init ---
+  function init(){
+    load();
+    // tasks
+    renderTasks();
+    // timer
+    workMins.value = state.settings.work;
+    breakMins.value = state.settings.break;
+    applySettings();
+    // notes
+    noteEl.value = state.note || '';
+    renderNote();
+  }
+  init();
+
+  // --- expose some hooks for Codex ---
+  window.__app = {
+    state, save, load, renderTasks, addTask, deleteTask, toggleTask,
+    renderSessions, applySettings, startTimer, pauseTimer, resetTimer,
+    renderNote
+  };
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add hidden `.sr-only` class for screen-reader labels
- label task and note fields with accessible text

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ddbd06a0832ab9225f0c980b3754